### PR TITLE
add another subpath level to `values.yaml` oap config override

### DIFF
--- a/chart/skywalking/templates/oap-cm-override.yaml
+++ b/chart/skywalking/templates/oap-cm-override.yaml
@@ -29,9 +29,16 @@ data:
 {{ $config | indent 4 }}
  {{- else }}
   {{- range $subpath, $subconfig := $config }}
+   {{- if typeIs "string" $subconfig }}
  {{ print $path "-" $subpath }}: |
 {{ $subconfig | indent 4 }}
+   {{- else }}
+     {{- range $subsubpath, $subsubconfig := $subconfig }}
+ {{ print $path "-" $subpath "-" $subsubpath }}: |
+{{ $subsubconfig | indent 4 }}
+     {{- end }}
+    {{- end }}
+   {{- end }}
   {{- end }}
  {{- end }}
-{{- end }}
 {{ end }}

--- a/chart/skywalking/templates/oap-deployment.yaml
+++ b/chart/skywalking/templates/oap-deployment.yaml
@@ -170,10 +170,18 @@ spec:
             mountPath: /skywalking/config/{{ $path }}
             subPath: {{ $path }}
           {{- else }}
-          {{- range $subpath, $oalContent := $config }}
+          {{- range $subpath, $subconfig := $config }}
+          {{- if typeIs "string" $subconfig }}
           - name: skywalking-oap-override
             mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}
             subPath: {{ print $path "-" $subpath }}
+          {{- else }}
+          {{- range $subsubpath, $subsubconfig := $subconfig }}
+          - name: skywalking-oap-override
+            mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}/{{ $subsubpath }}
+            subPath: {{ print $path "-" $subpath "-" $subsubpath }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/chart/skywalking/values.yaml
+++ b/chart/skywalking/values.yaml
@@ -102,6 +102,10 @@ oap:
     #   <Configuration status="DEBUG">
     #     <!-- ... -->
     #   </Configuration>
+    # ui-initialized-templates:
+    #   general:
+    #     general-service.json: |
+    #       [{"id":"General-Service" ... }]
   # When 'dynamicConfig.enabled' set to true, enable oap dynamic configuration through k8s configmap，
   # Note: The default configmap data is empty, please refer to the detailed documentation (https://github.com/apache/skywalking/blob/master/docs/en/setup/backend/dynamic-config.md)
   # Sync period in seconds. Defaults to 60 seconds.


### PR DESCRIPTION
@kezhenxu94's [PR ](https://github.com/apache/skywalking-helm/pull/99) was a great enhancement that gave the ability to set oap config override files from within `values.yaml`. But it only allows us to override files that are up to 1 level deep under `/skywalking/config`. 

For example:
- `alarm-settings.yaml` is directly under `/skywalking/config` which is 0 levels deep
- `core.oal` is under `/skywalking/config/oal/` which is 1 level deep

Why this PR?
SkyWalking has some configuration files like:
- `/skywalking/config/ui-initialized-templates/general/*`
- `/skywalking/config/openapi-definitions/serviceA/*`
Which are 2 levels deep and we need to have the ability to set them through `values.yaml`. So I just added one more level and now we can set override oap configurations this way

2 levels
```
    ui-initialized-templates:
      general:
        general-service.json: |
          [{"id":"General-Service" ........
```
1 level
```
     oal:
       core.oal: |
         service_resp_time = from(Service.latency).longAvg();
         service_sla = from(Service.*).percent(status == true);
         service_cpm = from(Service.*).cpm(); 
         ................
```
0 levels
```
    alarm-settings.yml: |
      rules:
        service_resp_time_rule:
          expression: sum(service_ .....
          .........
```
