### PR TITLE
Adding secret mount in the OAP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Release Notes.
 - Bump up BanyanDB Helm version to 0.2.0.
 - Bump up OAP and UI to 10.0.0.
 - Make release process work with Linux.
+- Support setting `secretMounts` in OAP.
 
 4.5.0
 ------------------

--- a/chart/skywalking/templates/oap-deployment.yaml
+++ b/chart/skywalking/templates/oap-deployment.yaml
@@ -185,10 +185,25 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{- range .Values.oap.secretMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .path }}
+            {{- if .subPath }}
+            subPath: {{ .subPath }}
+            {{- end }}
+          {{- end }}
 
       volumes:
         {{- if .Values.oap.config }}
         - name: skywalking-oap-override
           configMap:
             name: {{ template "skywalking.fullname" . }}-oap-cm-override
+        {{- end }}
+        {{- range .Values.oap.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+          {{- end }}
         {{- end }}

--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -98,9 +98,25 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{- range .Values.oap.secretMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .path }}
+            {{- if .subPath }}
+            subPath: {{ .subPath }}
+            {{- end }}
+          {{- end }}
+
       volumes:
         {{- if .Values.oap.config }}
         - name: skywalking-oap-override
           configMap:
             name: {{ template "skywalking.fullname" . }}-oap-cm-override
+        {{- end }}
+        {{- range .Values.oap.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
         {{- end }}

--- a/chart/skywalking/values.yaml
+++ b/chart/skywalking/values.yaml
@@ -126,6 +126,12 @@ oap:
     #       silence-period: 5
     #       Response time of service {name} is more than 1000ms in 3 minutes of last 10 minutes.
 
+  # A list of secrets and their paths to mount inside the pod
+  secretMounts: []
+#    - name: elastic-certificates
+#      secretName: elastic-certificates
+#      path: /usr/share/elasticsearch/config/certs
+
 ui:
   name: ui
   replicas: 1


### PR DESCRIPTION
I'm trying to add Cilium E2E in the main repo, and cilium will generate a TLS secret in the same namespace. When I tried to use this secret in the OAP, I found that the helm installing cannot appoint secrets in the OAP.  So I have added the `secretMounts` into the OAP configuration. 