### PR TITLE
Add auth password for user `postgres`

### DIFF
--- a/chart/skywalking/values.yaml
+++ b/chart/skywalking/values.yaml
@@ -444,6 +444,7 @@ postgresql:
     # The hostname of your own postgresql service, this only takes effect when postgresql.enabled is false.
     host: postgresql-service.your-awesome-company.com
   auth:
+    postgresPassword: "123456"
     username: postgres
     password: "123456"
     database: skywalking


### PR DESCRIPTION
without "postgresPassword “property, job "skywalking-skywalking-helm-oap-init" will fail. Cause the other auth properties didn't work for default account "postgres "， and  postgresql  generated a random password for the default account "postgres "。