### PR TITLE
Inconsistency in Volume Mounts Between oap-deployment.yaml and oap-job.yaml Causes Init Job to Fail

### DIFF
--- a/chart/skywalking/templates/oap-deployment.yaml
+++ b/chart/skywalking/templates/oap-deployment.yaml
@@ -164,46 +164,7 @@ spec:
         {{- end }}
 
         volumeMounts:
-          {{- range $path, $config := .Values.oap.config }}
-          {{- if typeIs "string" $config }}
-          - name: skywalking-oap-override
-            mountPath: /skywalking/config/{{ $path }}
-            subPath: {{ $path }}
-          {{- else }}
-          {{- range $subpath, $subconfig := $config }}
-          {{- if typeIs "string" $subconfig }}
-          - name: skywalking-oap-override
-            mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}
-            subPath: {{ print $path "-" $subpath }}
-          {{- else }}
-          {{- range $subsubpath, $subsubconfig := $subconfig }}
-          - name: skywalking-oap-override
-            mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}/{{ $subsubpath }}
-            subPath: {{ print $path "-" $subpath "-" $subsubpath }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
-          {{- range .Values.oap.secretMounts }}
-          - name: {{ .name }}
-            mountPath: {{ .path }}
-            {{- if .subPath }}
-            subPath: {{ .subPath }}
-            {{- end }}
-          {{- end }}
+        {{- include "skywalking.oap.volumeMounts" . | nindent 8 }}
 
       volumes:
-        {{- if .Values.oap.config }}
-        - name: skywalking-oap-override
-          configMap:
-            name: {{ template "skywalking.fullname" . }}-oap-cm-override
-        {{- end }}
-        {{- range .Values.oap.secretMounts }}
-        - name: {{ .name }}
-          secret:
-            secretName: {{ .secretName }}
-            {{- if .defaultMode }}
-            defaultMode: {{ .defaultMode }}
-          {{- end }}
-        {{- end }}
+      {{- include "skywalking.oap.volumes" . | nindent 6 }}

--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -91,10 +91,18 @@ spec:
             mountPath: /skywalking/config/{{ $path }}
             subPath: {{ $path }}
           {{- else }}
-          {{- range $subpath, $oalContent := $config }}
+          {{- range $subpath, $subconfig := $config }}
+          {{- if typeIs "string" $subconfig }}
           - name: skywalking-oap-override
             mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}
             subPath: {{ print $path "-" $subpath }}
+          {{- else }}
+          {{- range $subsubpath, $subsubconfig := $subconfig }}
+          - name: skywalking-oap-override
+            mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}/{{ $subsubpath }}
+            subPath: {{ print $path "-" $subpath "-" $subsubpath }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/chart/skywalking/templates/oap-init.job.yaml
+++ b/chart/skywalking/templates/oap-init.job.yaml
@@ -85,46 +85,7 @@ spec:
         {{- end }}
 
         volumeMounts:
-          {{- range $path, $config := .Values.oap.config }}
-          {{- if typeIs "string" $config }}
-          - name: skywalking-oap-override
-            mountPath: /skywalking/config/{{ $path }}
-            subPath: {{ $path }}
-          {{- else }}
-          {{- range $subpath, $subconfig := $config }}
-          {{- if typeIs "string" $subconfig }}
-          - name: skywalking-oap-override
-            mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}
-            subPath: {{ print $path "-" $subpath }}
-          {{- else }}
-          {{- range $subsubpath, $subsubconfig := $subconfig }}
-          - name: skywalking-oap-override
-            mountPath: /skywalking/config/{{ $path }}/{{ $subpath }}/{{ $subsubpath }}
-            subPath: {{ print $path "-" $subpath "-" $subsubpath }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
-          {{- range .Values.oap.secretMounts }}
-          - name: {{ .name }}
-            mountPath: {{ .path }}
-            {{- if .subPath }}
-            subPath: {{ .subPath }}
-            {{- end }}
-          {{- end }}
+        {{- include "skywalking.oap.volumeMounts" . | nindent 8 }}
 
       volumes:
-        {{- if .Values.oap.config }}
-        - name: skywalking-oap-override
-          configMap:
-            name: {{ template "skywalking.fullname" . }}-oap-cm-override
-        {{- end }}
-        {{- range .Values.oap.secretMounts }}
-        - name: {{ .name }}
-          secret:
-            secretName: {{ .secretName }}
-            {{- if .defaultMode }}
-            defaultMode: {{ .defaultMode }}
-            {{- end }}
-        {{- end }}
+      {{- include "skywalking.oap.volumes" . | nindent 6 }}


### PR DESCRIPTION
**Bug Description**
We've encountered an issue where the OAP server fails to start in init mode when custom Kubernetes metrics are enabled. The same configuration works perfectly for the server in no-init mode (the standard deployment).

The root cause appears to be an inconsistency in how the custom metrics files are mounted between the init Job and the standard Deployment.

**Steps to Reproduce**:

Give a config like:
```
otel-rules:
      k8s:
        custom-k8s-deployment-rules.yaml:
           ***
```

Install the helm.

**Expected Behavior**:
Both the init mode OAP server (Job) and the no-init mode OAP server (Deployment) start successfully.

**Actual Behavior**:
The standard OAP server pods (from oap-deployment.yaml) run successfully. However, the init-mode pod (from the Job template) fails with the following error, as it cannot find the mounted metric files:
```
org.apache.skywalking.oap.server.core.UnexpectedException: Some configuration files of enabled rules are not found, enabled rules: [k8s/*{.yaml,.yml}]
```
**Analysis**:
Upon inspecting the Helm templates, I found that the volume mount configurations in the OAP Job template differ from those in the oap-deployment.yaml.

I believe these configurations should be made consistent to ensure that both the Job and the Deployment pods could run successful.
